### PR TITLE
`AudioWorkerNode` is deprecated from specification

### DIFF
--- a/externs/chrome-externs/web-audio-auxiliary-extern.js
+++ b/externs/chrome-externs/web-audio-auxiliary-extern.js
@@ -34,29 +34,6 @@ function AnalyserNode() {}
  * @constructor
  * @extends {AudioNode}
  */
-function AudioWorkerNode() {}
-
-
-
-/**
- * @constructor
- */
-function AudioWorker() {}
-
-
-/**
- * @param {number} numberOfInputs
- * @param {number} numberOfOutputs
- * @return {!AudioWorkerNode}
- */
-AudioWorker.prototype.createNode = function(numberOfInputs, numberOfOutputs) {};
-
-
-
-/**
- * @constructor
- * @extends {AudioNode}
- */
 function ChannelMergerNode() {}
 
 

--- a/js/entry-points/tracing.js
+++ b/js/entry-points/tracing.js
@@ -1008,17 +1008,6 @@ audion.entryPoints.tracing = function() {
     audion.entryPoints.instrumentNode_(audioNode)
     return audioNode;
   }
-  if (typeof window['AudioWorkerNode'] == 'function') {
-    var constructorName = 'AudioWorkerNode';
-    var originalAudioWorkerNodeConstructor = AudioWorkerNode;
-    AudioWorkerNode = function() {
-      return createAudioNodeUsingConstructor(
-          originalAudioWorkerNodeConstructor,
-          Array.prototype.slice.call(arguments));
-    };
-    AudioWorkerNode['prototype'] = originalAudioWorkerNodeConstructor.prototype;
-    AudioWorkerNode['prototype']['constructor'] = AudioWorkerNode;
-  }
   if (typeof window['AnalyserNode'] == 'function') {
     var constructorName = 'AnalyserNode';
     var originalAnalyserNodeConstructor = AnalyserNode;
@@ -1256,15 +1245,6 @@ audion.entryPoints.tracing = function() {
   OfflineAudioContext.prototype =
       nativeOfflineAudioContextConstructor.prototype;
   OfflineAudioContext.prototype.constructor = OfflineAudioContext;
-
-  if (window['AudioWorker']) {
-    /**
-     * Instrument AudioWorker.
-     * @override
-     */
-    AudioWorker.prototype.createNode = wrapNativeFunction(
-        AudioWorker.prototype.createNode, newNodeDecorator);
-  }
 
   // Listen to messages on the window that are related to the extension.
   // Listen to messages from the page. Relay them to the background script.


### PR DESCRIPTION
`AudioWorkerNode` is deprecated from specification.

NOTE:

- [The lastest](https://www.w3.org/TR/webaudio/)
- [20151208#AudioWorker](https://www.w3.org/TR/2015/WD-webaudio-20151208/#AudioWorker) 
