### PR TITLE
`SpatialPannerNode` is deprecated from specification

### DIFF
--- a/externs/chrome-externs/web-audio-auxiliary-extern.js
+++ b/externs/chrome-externs/web-audio-auxiliary-extern.js
@@ -73,21 +73,6 @@ function ChannelSplitterNode() {}
  * @constructor
  * @extends {AudioNode}
  */
-function SpatialPannerNode() {}
-
-
-
-/**
- * @return {!SpatialPannerNode}
- */
-AudioContext.prototype.createSpatialPanner = function() {};
-
-
-
-/**
- * @constructor
- * @extends {AudioNode}
- */
 function IIRFilterNode() {}
 
 


### PR DESCRIPTION
> Merge the SpatialPannerNode into the PannerNode, undeprecating the PannerNode

https://www.w3.org/TR/webaudio/